### PR TITLE
Keep pip installed, and install jre

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ RUN apk --no-cache --update add \
         build-base \
         gcc \
         git \
+	      openjdk8-jre \
         openssh \
         openssh-client \
         openssl \
@@ -21,8 +22,6 @@ RUN apk --no-cache --update add \
         nodejs-npm \
         && \
     pip install --upgrade awscli==1.16.20 s3cmd==2.0.1 python-magic && \
-    apk -v --purge del py-pip \
-      && \
     wget https://releases.hashicorp.com/terraform/0.11.14/terraform_0.11.14_linux_amd64.zip -O tmp.zip && unzip tmp.zip -d /usr/local/bin/; rm tmp.zip \
       && \
     rm -rf .terraform \


### PR DESCRIPTION
This keeps pip installed for setup.py uploads and installs jre. 