### PR TITLE
Update aws cli to 1.16.228 for events

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN apk --no-cache --update add \
         nodejs \
         nodejs-npm \
         && \
-    pip install --upgrade awscli==1.16.20 s3cmd==2.0.1 python-magic && \
+    pip install --upgrade awscli==1.16.228 s3cmd==2.0.1 python-magic && \
     wget https://releases.hashicorp.com/terraform/0.11.14/terraform_0.11.14_linux_amd64.zip -O tmp.zip && unzip tmp.zip -d /usr/local/bin/; rm tmp.zip \
       && \
     rm -rf .terraform \

--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
 # cdhci_aws_node_golang_terraform
-awscli@1.16 go@1.12 terraform@0.11.14 node@8
+awscli@1.16.228 go@1.12 terraform@0.11.14 node@8


### PR DESCRIPTION
We need this update in order to use several of the new Eventbridge api actions, I know not exactly semver, but 1.16.20 did not have a few actions off the events stem. 