### PR TITLE
go-build-lambda script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,3 +40,6 @@ RUN tfenv install 0.11.14 && \
     tfenv install 0.12.12
     
 RUN tfenv use 0.12.12
+
+COPY scripts/go-build-lambda /usr/local/bin
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,14 @@
 FROM golang:1.13-alpine
 
 RUN apk --no-cache --update add \
-		autoconf \
-		automake \
+        autoconf \
+        automake \
         bash \
         build-base \
         gcc \
         curl \
         git \
-		openjdk8-jre \
+        openjdk8-jre \
         openssh \
         openssh-client \
         openssl \
@@ -23,7 +23,7 @@ RUN apk --no-cache --update add \
         mailcap \
         nodejs \
         nodejs-npm \
-		zlib-dev \
+        zlib-dev \
         && \
     pip install --upgrade awscli==1.16.228 s3cmd==2.0.1 python-magic && \
     wget https://github.com/go-swagger/go-swagger/releases/download/v0.21.0/swagger_linux_amd64 -O /usr/local/bin/swagger && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,14 @@
 FROM golang:1.13-alpine
 
 RUN apk --no-cache --update add \
-	autoconf \
-	automake \
+		autoconf \
+		automake \
         bash \
         build-base \
         gcc \
         curl \
         git \
-	openjdk8-jre \
+		openjdk8-jre \
         openssh \
         openssh-client \
         openssl \
@@ -23,7 +23,7 @@ RUN apk --no-cache --update add \
         mailcap \
         nodejs \
         nodejs-npm \
-	zlib-dev \
+		zlib-dev \
         && \
     pip install --upgrade awscli==1.16.228 s3cmd==2.0.1 python-magic && \
     wget https://github.com/go-swagger/go-swagger/releases/download/v0.21.0/swagger_linux_amd64 -O /usr/local/bin/swagger && \
@@ -42,4 +42,3 @@ RUN tfenv install 0.11.14 && \
 RUN tfenv use 0.12.12
 
 COPY scripts/go-build-lambda /usr/local/bin
-

--- a/scripts/go-build-lambda
+++ b/scripts/go-build-lambda
@@ -1,11 +1,14 @@
 #!/usr/bin/env bash
 
 export LDFlags=""
-if [[ "$OS" == "Windows_NT" ]]; then
-	UNAME_S=$(shell uname -s)
+export LDFlagPrefix=""
+if [[ "$OS" != "Windows_NT" ]]; then
+	UNAME_S=$(uname -s)
 	if [[ "$UNAME_S" == "Linux" ]]; then
-		LDFlags=-ldflags="-linkmode external -extldflags -static -s -w"
+	  LDFlagPrefix=-ldflags=
+		LDFlags="-linkmode external -extldflags -static -s -w"
 	fi
 fi
+echo "Building with flags: $LDFlags"
 
-GOOS=linux GOARCH=amd64 go build $LDFlags -tags netgo --installsuffix netgo "$@"
+GOOS=linux GOARCH=amd64 go build $LDFlagPrefix"$LDFlags" -tags netgo --installsuffix netgo "$@"

--- a/scripts/go-build-lambda
+++ b/scripts/go-build-lambda
@@ -1,14 +1,7 @@
 #!/usr/bin/env bash
 
-export LDFlags=""
-export LDFlagPrefix=""
-if [[ "$OS" != "Windows_NT" ]]; then
-	UNAME_S=$(uname -s)
-	if [[ "$UNAME_S" == "Linux" ]]; then
-	  LDFlagPrefix=-ldflags=
-		LDFlags="-linkmode external -extldflags -static -s -w"
-	fi
+if [[ "$OS" != "Windows_NT" && "$(uname -s)" == "Linux" ]]; then
+  GOOS=linux GOARCH=amd64 go build -ldflags="-linkmode external -extldflags -static -s -w" -tags netgo --installsuffix netgo "$@"
+else
+  GOOS=linux GOARCH=amd64 go build -tags netgo --installsuffix netgo "$@"
 fi
-echo "Building with flags: $LDFlags"
-
-GOOS=linux GOARCH=amd64 go build $LDFlagPrefix"$LDFlags" -tags netgo --installsuffix netgo "$@"

--- a/scripts/go-build-lambda
+++ b/scripts/go-build-lambda
@@ -1,16 +1,11 @@
 #!/usr/bin/env bash
 
-LDFlags :=
-ifeq ($(OS),Windows_NT)
-else
-	UNAME_S := $(shell uname -s)
-	ifeq ($(UNAME_S),Linux)
-		CPFlags += -Lr
-		LDFlags += -ldflags="-linkmode external -extldflags -static -s -w"
-	endif
-	ifeq ($(UNAME_S),Darwin)
-		CPFlags += -r
-	endif
-endif
+export LDFlags=""
+if [[ "$OS" == "Windows_NT" ]]; then
+	UNAME_S=$(shell uname -s)
+	if [[ "$UNAME_S" == "Linux" ]]; then
+		LDFlags=-ldflags="-linkmode external -extldflags -static -s -w"
+	fi
+fi
 
-GOOS=linux GOARCH=amd64 go build $(LDFlags) -tags netgo --installsuffix netgo "$@"
+GOOS=linux GOARCH=amd64 go build $LDFlags -tags netgo --installsuffix netgo "$@"

--- a/scripts/go-build-lambda
+++ b/scripts/go-build-lambda
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+LDFlags :=
+ifeq ($(OS),Windows_NT)
+else
+	UNAME_S := $(shell uname -s)
+	ifeq ($(UNAME_S),Linux)
+		CPFlags += -Lr
+		LDFlags += -ldflags="-linkmode external -extldflags -static -s -w"
+	endif
+	ifeq ($(UNAME_S),Darwin)
+		CPFlags += -r
+	endif
+endif
+
+GOOS=linux GOARCH=amd64 go build $(LDFlags) -tags netgo --installsuffix netgo "$@"


### PR DESCRIPTION
adds a cli util that sets correct build flags for go programs intended to run in a lambda environment

ex. `go-build-lambda -o foo.go foo`